### PR TITLE
Sort favorites before other bookmarks

### DIFF
--- a/scope/client.cpp
+++ b/scope/client.cpp
@@ -39,13 +39,13 @@ BookmarkList get_bookmarks(std::string query, int sort) {
 
     sqlite3 *db;
     sqlite3_stmt *stmt;
-    std::string sql = "SELECT url, title, icon FROM bookmarks";
+    std::string sql = "SELECT url, title, icon, favorite FROM bookmarks";
     if (query != "")
         sql += " WHERE (url LIKE '%' || ? || '%' OR title LIKE '%' || ?1 || '%')";
     if (sort == 0)
-        sql += " ORDER BY length(title) > 0 DESC, title ASC";
+        sql += " ORDER BY favorite DESC, length(title) > 0 DESC, title ASC";
     else
-        sql += " ORDER BY created DESC";
+        sql += " ORDER BY favorite DESC, created DESC";
 
     if (!run_statement(sql, &db, &stmt))
         goto exit;
@@ -64,6 +64,7 @@ BookmarkList get_bookmarks(std::string query, int sort) {
             b.url = sqlite3_column_string(stmt, 0, "");
             b.title = sqlite3_column_string(stmt, 1, b.url);
             b.icon = sqlite3_column_string(stmt, 2, "file:///usr/share/icons/suru/actions/scalable/stock_website.svg");
+            b.favorite = sqlite3_column_int(stmt, 3);
             bookmarks.emplace_back(b);
             res = sqlite3_step(stmt);
         }

--- a/scope/client.h
+++ b/scope/client.h
@@ -13,6 +13,7 @@ struct Bookmark {
     std::string url;
     std::string title;
     std::string icon;
+    int favorite;
 };
 
 typedef std::deque<Bookmark> BookmarkList;

--- a/scope/query.cpp
+++ b/scope/query.cpp
@@ -54,11 +54,20 @@ void Query::run(sc::SearchReplyProxy const& reply) {
     Client::BookmarkList bookmarks =
             Client::get_bookmarks(query.query_string(), sort);
 
-    auto cat = reply->register_category("bookmarks", "", "",
-                                        sc::CategoryRenderer(BOOKMARK_TEMPLATE));
+    if (!bookmarks.size())
+        // Explanatory text
+        return;
+
+    auto fav_cat = reply->register_category("favorites", "", "",
+                                            sc::CategoryRenderer(BOOKMARK_TEMPLATE));
+    // Check to see if any bookmarks have been favorited (they come first)
+    bool areFavorites = (bookmarks[0].favorite > 0);
+    // No need for a label if no bookmarks are favorited
+    auto all_cat = reply->register_category("bookmarks", areFavorites ? _("Unsorted") : "", "",
+                                            sc::CategoryRenderer(BOOKMARK_TEMPLATE));
 
     for (const Client::Bookmark bookmark : bookmarks) {
-        sc::CategorisedResult res(cat);
+        sc::CategorisedResult res(bookmark.favorite ? fav_cat : all_cat);
         res.set_uri(bookmark.url);
         res.set_title(bookmark.title);
         res.set_art(bookmark.icon);


### PR DESCRIPTION
Larger favorite values are sorted earlier.  There is a label for the
unsorted category only when there are some favorites; otherwise, there's
only one category and no need for the label.
