### PR TITLE
Improvements to the scope's query presentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ install(DIRECTORY "app/graphics" DESTINATION ${DATA_DIR})
 install(FILES "addtodash.apparmor" DESTINATION ${DATA_DIR})
 install(FILES "addtodash-scope.apparmor" DESTINATION ${DATA_DIR})
 install(FILES "addtodash.contenthub" DESTINATION ${DATA_DIR})
+install(FILES "addtodash.url-dispatcher" DESTINATION ${DATA_DIR})
 
 add_subdirectory(app)
 add_subdirectory(po)
@@ -74,6 +75,7 @@ add_custom_target("addtodash_ClickFiles" ALL SOURCES
                   "addtodash.apparmor"
                   "addtodash-scope.apparmor"
                   "addtodash.contenthub"
+                  "addtodash.url-dispatcher"
                   "manifest.json.in"
                   "scope/data/addtodash.ini.in"
                   "scope/data/addtodash-settings.ini.in")

--- a/addtodash.url-dispatcher
+++ b/addtodash.url-dispatcher
@@ -1,0 +1,1 @@
+[{"protocol": "addtodash", "domain-suffix": "manage"}]

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -7,7 +7,8 @@
         "addtodash": {
             "apparmor": "addtodash.apparmor",
             "desktop": "addtodash.desktop",
-            "content-hub": "addtodash.contenthub"
+            "content-hub": "addtodash.contenthub",
+            "urls": "addtodash.url-dispatcher"
         },
         "addtodash-scope": {
             "apparmor": "addtodash-scope.apparmor",

--- a/scope/CMakeLists.txt
+++ b/scope/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(
 
 # If we need to refer to the scope's name or package in code, these definitions will help
 add_definitions(-DPACKAGE_NAME="${PACKAGE_NAME}")
+add_definitions(-DAPP_ID="${APP_ID}")
 add_definitions(-DSCOPE_NAME="${SCOPE_NAME}")
 add_definitions(-DGETTEXT_PACKAGE="${GETTEXT_PACKAGE}")
 

--- a/scope/client.cpp
+++ b/scope/client.cpp
@@ -40,14 +40,17 @@ BookmarkList get_bookmarks(std::string query, int sort) {
     sqlite3 *db;
     sqlite3_stmt *stmt;
     std::string sql = "SELECT url, title, icon, favorite FROM bookmarks";
+    std::string sort_sql = " ORDER BY ";
     if (query != "")
         sql += " WHERE (url LIKE '%' || ? || '%' OR title LIKE '%' || ?1 || '%')";
-    if (sort == 0)
-        sql += " ORDER BY favorite DESC, length(title) > 0 DESC, title ASC";
     else
-        sql += " ORDER BY favorite DESC, created DESC";
+        sort_sql += "favorite DESC, ";
+    if (sort == 0)
+        sort_sql += "length(title) > 0 DESC, title ASC";
+    else
+        sort_sql += "created DESC";
 
-    if (!run_statement(sql, &db, &stmt))
+    if (!run_statement(sql + sort_sql, &db, &stmt))
         goto exit;
 
     if (query != "") {

--- a/scope/query.cpp
+++ b/scope/query.cpp
@@ -32,8 +32,7 @@ const static string BOOKMARK_TEMPLATE =
         "title": "title",
         "art" : {
         "field": "art"
-        },
-        "subtitle": "subtitle"
+        }
         }
         }
         )";

--- a/scope/query.cpp
+++ b/scope/query.cpp
@@ -51,6 +51,7 @@ void Query::run(sc::SearchReplyProxy const& reply) {
     const sc::CannedQuery &query(sc::SearchQueryBase::query());
 
     int sort = settings().at("sort").get_int();
+    bool has_query = (query.query_string() != "");
     Client::BookmarkList bookmarks =
             Client::get_bookmarks(query.query_string(), sort);
 
@@ -67,7 +68,8 @@ void Query::run(sc::SearchReplyProxy const& reply) {
                                             sc::CategoryRenderer(BOOKMARK_TEMPLATE));
 
     for (const Client::Bookmark bookmark : bookmarks) {
-        sc::CategorisedResult res(bookmark.favorite ? fav_cat : all_cat);
+        // If running a query, don't put results into different categories.
+        sc::CategorisedResult res((bookmark.favorite || has_query) ? fav_cat : all_cat);
         res.set_uri(bookmark.url);
         res.set_title(bookmark.title);
         res.set_art(bookmark.icon);

--- a/scope/query.cpp
+++ b/scope/query.cpp
@@ -38,6 +38,23 @@ const static string BOOKMARK_TEMPLATE =
         }
         )";
 
+const static string MANAGEMENT_TEMPLATE =
+        R"(
+{
+        "schema-version": 1,
+        "template": {
+        "category-layout": "grid",
+        "card-layout": "vertical",
+        "card-size": "large",
+        "card-background": "color:///white"
+        },
+        "components": {
+        "title": "title",
+        "mascot": "art"
+        }
+        }
+        )";
+
 Query::Query(const sc::CannedQuery &query, const sc::SearchMetadata &metadata) :
     sc::SearchQueryBase(query, metadata) {
 }
@@ -79,6 +96,17 @@ void Query::run(sc::SearchReplyProxy const& reply) {
             // Query has been cancelled.
             return;
         }
+    }
+
+    if (!has_query) {
+        auto management_cat = reply->register_category("management", "", "",
+                                                       sc::CategoryRenderer(MANAGEMENT_TEMPLATE));
+        sc::CategorisedResult res(management_cat);
+        res.set_title(_("Manage Bookmarks"));
+        res.set_art("file:///opt/click.ubuntu.com/" APP_ID "/current/graphics/addtodash.png");
+        res.set_uri("addtodash://manage");
+        res.set_intercept_activation();
+        reply->push(res);
     }
 }
 


### PR DESCRIPTION
No segregation during searches.  Link to management app.

@stuartlangridge The one thing you might be interested in the the URL dispatcher part.  I've made the management app claim the addtodash://manage URL.  My thought is that the various containers can claim addtodash://containerN.  But if you think it'd be better for each to have their own protocol, we can do that too.
