### PR TITLE
Hide containers from app scope and make them load a URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(DESKTOP_FILE_NAME "addtodash.desktop")
 
 # This sets the commandline that is executed on the device
 set(EXEC "qmlscene $@ ${ADDTODASH_DIR}/${MAIN_QML}")
-set(EXEC_CONTAINER "qmlscene $@ ${CONTAINER_DIR}/${MAIN_QML}")
+set(EXEC_CONTAINER "qmlscene %U ${CONTAINER_DIR}/${MAIN_QML}")
 
 set(HOOKS "")
 foreach(N RANGE ${N_MAX})

--- a/container/addtodash-container.desktop.in
+++ b/container/addtodash-container.desktop.in
@@ -6,3 +6,4 @@ Terminal=false
 Type=Application
 #NoDisplay=true
 X-Ubuntu-Touch=true
+OnlyShowIn=Old


### PR DESCRIPTION
Use undocumented OnlyShowIn=Old desktop file key to hide the containers from the app scope.
Correct Exec line for containers to make the passed URL appear on the command line.
